### PR TITLE
Fix Kernel struct decoding

### DIFF
--- a/Gamepad.py
+++ b/Gamepad.py
@@ -70,7 +70,7 @@ class Gamepad:
                     time.sleep(0.5)
                 else:
                     raise IOError('Could not open gamepad %s: %s' % (self.joystickNumber, str(e)))
-        self.eventSize = struct.calcsize('LhBB')
+        self.eventSize = struct.calcsize('IhBB')
         self.pressedMap = {}
         self.wasPressedMap = {}
         self.wasReleasedMap = {}
@@ -115,7 +115,7 @@ class Gamepad:
                 self.connected = False
                 raise IOError('Gamepad %s disconnected' % self.joystickNumber)
             else:
-                return struct.unpack('LhBB', rawEvent)
+                return struct.unpack('IhBB', rawEvent)
         else:
             raise IOError('Gamepad has been disconnected')
 


### PR DESCRIPTION
I made this work on ubuntu, the issue was the size of the timestamp field in the struct.

Yes the python doc states bot I and L are 32 bit, but my testing proves this wrong.

I tested this on ubuntu 20.04 64 bit. I assume the 64 bit causes the issue in the first place, not actually ubuntu.

[Struct definition I used] https://github.com/torvalds/linux/blob/master/Documentation/input/joydev/joystick-api.rst

This should fix #2